### PR TITLE
Alter the join/leave message style

### DIFF
--- a/moon/cfc_chat_transit/server/init.moon
+++ b/moon/cfc_chat_transit/server/init.moon
@@ -80,13 +80,16 @@ ChatTransit.ReceiveMessage = (ply, text, teamChat) =>
 
 ChatTransit.PlayerInitialSpawn = (ply) =>
     sendMessage = (attempts=1) ->
+        local avatar
+
         if attempts >= 5
             @Logger\warn "PlayerSummary didn't exist in time to send an on-spawn message"
         else
-            if not ply.PlayerSummary
+            if ply.PlayerSummary
+                avatar = ply.PlayerSummary.response.players[1].avatarfull
+            else
                 return timer.Simple 2, -> sendMessage(attempts + 1)
 
-        avatar = ply.PlayerSummary.response.players[1].avatarfull
         steamName = ply\Nick!
         steamId = ply\SteamID64!
 

--- a/moon/cfc_chat_transit/server/init.moon
+++ b/moon/cfc_chat_transit/server/init.moon
@@ -102,6 +102,8 @@ ChatTransit.PlayerInitialSpawn = (ply) =>
 
         @WebSocket\write message
 
+    sendMessage!
+
 ChatTransit.PlayerDisconnected = (data) =>
     avatar = ply.PlayerSummary.response.players[1].avatarfull
     steamName = ply\Nick!

--- a/moon/cfc_chat_transit/server/init.moon
+++ b/moon/cfc_chat_transit/server/init.moon
@@ -81,10 +81,10 @@ ChatTransit.ReceiveMessage = (ply, text, teamChat) =>
 ChatTransit.PlayerInitialSpawn = (ply) =>
     sendMessage = (attempts=1) ->
         if attempts >= 5
-            return @Logger\error "PlayerSummary didn't exist in time to send an on-spawn message"
-
-        if not ply.PlayerSummary
-            return timer.Simple 2, -> sendMessage(attempts + 1)
+            @Logger\warn "PlayerSummary didn't exist in time to send an on-spawn message"
+        else
+            if not ply.PlayerSummary
+                return timer.Simple 2, -> sendMessage(attempts + 1)
 
         avatar = ply.PlayerSummary.response.players[1].avatarfull
         steamName = ply\Nick!

--- a/web/discord_relay/queue.go
+++ b/web/discord_relay/queue.go
@@ -33,15 +33,10 @@ var WebhookSecret string = os.Getenv("WEBHOOK_SECRET")
 
 const (
 	JOIN_EMOJI  = "<:green_cross_cir:654105378933571594>"
-	LEAVE_EMOJI = "<:circle_red:855605697978957854>"
+	LEAVE_EMOJI = "<:red_cross_cir:645096379647000597>"
 )
 
 func sendMessage(discord *discordgo.Session, message MessageStruct) {
-	//profileUrl := "https://steamcommunity.com/profiles/" + message.SteamId
-	//joinUrl := "https://cfcservers.org/" + strings.ToLower(message.Realm) + "/join"
-	//contentBuilder.WriteString(fmt.Sprintf("[%v](<%v>) ", JOIN_EMOJI, joinUrl))
-	//contentBuilder.WriteString(fmt.Sprintf("[%v](<%v>) ", STEAM_EMOJI, profileUrl))
-
 	params := &discordgo.WebhookParams{
 		AllowedMentions: &discordgo.MessageAllowedMentions{
 			Parse: []discordgo.AllowedMentionType{},
@@ -59,8 +54,14 @@ func sendConnectMessage(discord *discordgo.Session, message MessageStruct) {
 		AllowedMentions: &discordgo.MessageAllowedMentions{
 			Parse: []discordgo.AllowedMentionType{},
 		},
-		Content:  fmt.Sprintf("%v %v | %v has connected to the server", JOIN_EMOJI, message.Data.SteamName, message.Data.SteamId),
-		Username: "Relay",
+		Username:  message.Data.SteamName,
+		AvatarURL: message.Data.Avatar,
+		Embeds: []discordgo.MessageEmbed{
+		    &discordgo.MessageEmbed{
+                Description: fmt.Sprintf("%v ***Connected to the server***", JOIN_EMOJI),
+                Color:       65280,
+            },
+		},
 	}
 
 	discord.WebhookExecute(WebhookId, WebhookSecret, true, params)
@@ -71,8 +72,14 @@ func sendDisconnectMessage(discord *discordgo.Session, message MessageStruct) {
 		AllowedMentions: &discordgo.MessageAllowedMentions{
 			Parse: []discordgo.AllowedMentionType{},
 		},
-		Content:  fmt.Sprintf("%v %v | %v has disconnected from the server", LEAVE_EMOJI, message.Data.SteamName, message.Data.SteamId),
-		Username: "Relay",
+		Username:  message.Data.SteamName,
+		AvatarURL: message.Data.Avatar,
+		Embeds: []discordgo.MessageEmbed{
+		    &discordgo.MessageEmbed{
+                Description: fmt.Sprintf("%v ***Disconnected from the server***", LEAVE_EMOJI),
+                Color:       16711680,
+            },
+		},
 	}
 
 	discord.WebhookExecute(WebhookId, WebhookSecret, true, params)

--- a/web/discord_relay/queue.go
+++ b/web/discord_relay/queue.go
@@ -56,8 +56,8 @@ func sendConnectMessage(discord *discordgo.Session, message MessageStruct) {
 		},
 		Username:  message.Data.SteamName,
 		AvatarURL: message.Data.Avatar,
-		Embeds: []discordgo.MessageEmbed{
-			&discordgo.MessageEmbed{
+		Embeds: []*discordgo.MessageEmbed{
+			{
 				Description: fmt.Sprintf("%v ***Spawned in the server***", JOIN_EMOJI),
 				Color:       0x65280,
 			},
@@ -74,8 +74,8 @@ func sendDisconnectMessage(discord *discordgo.Session, message MessageStruct) {
 		},
 		Username:  message.Data.SteamName,
 		AvatarURL: message.Data.Avatar,
-		Embeds: []discordgo.MessageEmbed{
-			&discordgo.MessageEmbed{
+		Embeds: []*discordgo.MessageEmbed{
+			{
 				Description: fmt.Sprintf("%v ***Disconnected from the server***", LEAVE_EMOJI),
 				Color:       0x16711680,
 			},

--- a/web/discord_relay/queue.go
+++ b/web/discord_relay/queue.go
@@ -58,7 +58,7 @@ func sendConnectMessage(discord *discordgo.Session, message MessageStruct) {
 		AvatarURL: message.Data.Avatar,
 		Embeds: []discordgo.MessageEmbed{
 			&discordgo.MessageEmbed{
-				Description: fmt.Sprintf("%v ***Connected to the server***", JOIN_EMOJI),
+				Description: fmt.Sprintf("%v ***Spawned in the server***", JOIN_EMOJI),
 				Color:       65280,
 			},
 		},

--- a/web/discord_relay/queue.go
+++ b/web/discord_relay/queue.go
@@ -59,7 +59,7 @@ func sendConnectMessage(discord *discordgo.Session, message MessageStruct) {
 		Embeds: []discordgo.MessageEmbed{
 			&discordgo.MessageEmbed{
 				Description: fmt.Sprintf("%v ***Spawned in the server***", JOIN_EMOJI),
-				Color:       65280,
+				Color:       0x65280,
 			},
 		},
 	}
@@ -77,7 +77,7 @@ func sendDisconnectMessage(discord *discordgo.Session, message MessageStruct) {
 		Embeds: []discordgo.MessageEmbed{
 			&discordgo.MessageEmbed{
 				Description: fmt.Sprintf("%v ***Disconnected from the server***", LEAVE_EMOJI),
-				Color:       16711680,
+				Color:       0x16711680,
 			},
 		},
 	}

--- a/web/discord_relay/queue.go
+++ b/web/discord_relay/queue.go
@@ -57,10 +57,10 @@ func sendConnectMessage(discord *discordgo.Session, message MessageStruct) {
 		Username:  message.Data.SteamName,
 		AvatarURL: message.Data.Avatar,
 		Embeds: []discordgo.MessageEmbed{
-		    &discordgo.MessageEmbed{
-                Description: fmt.Sprintf("%v ***Connected to the server***", JOIN_EMOJI),
-                Color:       65280,
-            },
+			&discordgo.MessageEmbed{
+				Description: fmt.Sprintf("%v ***Connected to the server***", JOIN_EMOJI),
+				Color:       65280,
+			},
 		},
 	}
 
@@ -75,10 +75,10 @@ func sendDisconnectMessage(discord *discordgo.Session, message MessageStruct) {
 		Username:  message.Data.SteamName,
 		AvatarURL: message.Data.Avatar,
 		Embeds: []discordgo.MessageEmbed{
-		    &discordgo.MessageEmbed{
-                Description: fmt.Sprintf("%v ***Disconnected from the server***", LEAVE_EMOJI),
-                Color:       16711680,
-            },
+			&discordgo.MessageEmbed{
+				Description: fmt.Sprintf("%v ***Disconnected from the server***", LEAVE_EMOJI),
+				Color:       16711680,
+			},
 		},
 	}
 


### PR DESCRIPTION
This should make the messages look like the rest, but with a small embed saying when they spawned and when they disconnected.

Decided to go with `PlayerInitialSpawn` because people will probably care more about when someone spawns than when they connect. (Also I get access to the actual player object at that point)
