### PR TITLE
Use later hook to determine startup

### DIFF
--- a/moon/cfc_chat_transit/server/modules/startup.moon
+++ b/moon/cfc_chat_transit/server/modules/startup.moon
@@ -16,4 +16,4 @@ ChatTransit.MapStartup = (data) =>
         Data:
             Content: eventText
 
-hook.Add "Initialize", "CFC_ChatTransit_StartListener", guard ChatTransit\MapStartup
+hook.Add "InitPostEntity", "CFC_ChatTransit_StartListener", guard ChatTransit\MapStartup

--- a/moon/cfc_chat_transit/server/modules/startup.moon
+++ b/moon/cfc_chat_transit/server/modules/startup.moon
@@ -16,4 +16,5 @@ ChatTransit.MapStartup = (data) =>
         Data:
             Content: eventText
 
-hook.Add "InitPostEntity", "CFC_ChatTransit_StartListener", guard ChatTransit\MapStartup
+hook.Add "InitPostEntity", "CFC_ChatTransit_StartListener", timer.Simple 1, guard ChatTransit\MapStartup
+


### PR DESCRIPTION
Currently the avatar service starts at InitPostEntity, the startup check should run after this. This might not even fully work as the avatar service gets ready at the InitPostEntity as well. Might have to use some kind of timer but i feel like that'd be nasty 