### PR TITLE
Add playercount tracker

### DIFF
--- a/moon/cfc_chat_transit/server/modules/connect.moon
+++ b/moon/cfc_chat_transit/server/modules/connect.moon
@@ -13,7 +13,7 @@ ChatTransit.PlayerConnect = (data) =>
         Data:
             SteamName: name
             SteamId: steamId and SteamIDTo64 steamId
-            PlayerCountCurrent: player\GetCount! + 1
+            PlayerCountCurrent: ChatTransit.PlayerCount
             PlayerCountMax: game\MaxPlayers!
 
 ChatTransit.PlayerInitialSpawn = (ply) =>

--- a/moon/cfc_chat_transit/server/modules/disconnect.moon
+++ b/moon/cfc_chat_transit/server/modules/disconnect.moon
@@ -12,7 +12,7 @@ ChatTransit.PlayerDisconnected = (data) =>
         Data:
             SteamName: ply and ply\Nick! or name
             SteamId: ply and ply\SteamID64! or SteamIDTo64 steamId
-            PlayerCountCurrent: player\GetCount! - 1
+            PlayerCountCurrent: ChatTransit.PlayerCount
             PlayerCountMax: game\MaxPlayers!
             Content: reason
 

--- a/moon/cfc_chat_transit/server/modules/playercount.moon
+++ b/moon/cfc_chat_transit/server/modules/playercount.moon
@@ -3,10 +3,10 @@ gameevent.Listen "player_disconnect"
 
 with ChatTransit
     .PlayerCount = 0
-    .TrackPlayerCountConnected = () =>
+    .TrackPlayerCountConnected = ->
         .PlayerCount = .PlayerCount + 1
 
-    .TrackPlayerCountDisconnected = () =>
+    .TrackPlayerCountDisconnected = ->
         .PlayerCount = .PlayerCount - 1
 
     hook.Add "player_connect", "CFC_ChatTransit_PlayerCountTracker", .TrackPlayerCountConnected

--- a/moon/cfc_chat_transit/server/modules/playercount.moon
+++ b/moon/cfc_chat_transit/server/modules/playercount.moon
@@ -11,4 +11,3 @@ ChatTransit.TrackPlayerCountDisconnected = () =>
 
 hook.Add "player_connect", "CFC_ChatTransit_PlayerCountTracker", ChatTransit.TrackPlayerCountConnected
 hook.Add "player_disconnect", "CFC_ChatTransit_PlayerCountTracker", ChatTransit.TrackPlayerCountDisconnected
-diff --git a/moon/cfc_chat_transit/server/modules/disconnect.moon b/moon/cfc_chat_transit/server/modules/disconnect.moon

--- a/moon/cfc_chat_transit/server/modules/playercount.moon
+++ b/moon/cfc_chat_transit/server/modules/playercount.moon
@@ -1,0 +1,14 @@
+ChatTransit.PlayerCount = 0
+
+gameevent.Listen "player_connect"
+gameevent.Listen "player_disconnect"
+
+ChatTransit.TrackPlayerCountConnected = () =>
+    ChatTransit.PlayerCount = ChatTransit.PlayerCount + 1
+
+ChatTransit.TrackPlayerCountDisconnected = () =>
+    ChatTransit.PlayerCount = ChatTransit.PlayerCount - 1
+
+hook.Add "player_connect", "CFC_ChatTransit_PlayerCountTracker", ChatTransit.TrackPlayerCountConnected
+hook.Add "player_disconnect", "CFC_ChatTransit_PlayerCountTracker", ChatTransit.TrackPlayerCountDisconnected
+diff --git a/moon/cfc_chat_transit/server/modules/disconnect.moon b/moon/cfc_chat_transit/server/modules/disconnect.moon

--- a/moon/cfc_chat_transit/server/modules/playercount.moon
+++ b/moon/cfc_chat_transit/server/modules/playercount.moon
@@ -1,13 +1,13 @@
-ChatTransit.PlayerCount = 0
-
 gameevent.Listen "player_connect"
 gameevent.Listen "player_disconnect"
 
-ChatTransit.TrackPlayerCountConnected = () =>
-    ChatTransit.PlayerCount = ChatTransit.PlayerCount + 1
+with ChatTransit
+    .PlayerCount = 0
+    .TrackPlayerCountConnected = () =>
+        .PlayerCount = .PlayerCount + 1
 
-ChatTransit.TrackPlayerCountDisconnected = () =>
-    ChatTransit.PlayerCount = ChatTransit.PlayerCount - 1
+    .TrackPlayerCountDisconnected = () =>
+        .PlayerCount = .PlayerCount - 1
 
-hook.Add "player_connect", "CFC_ChatTransit_PlayerCountTracker", ChatTransit.TrackPlayerCountConnected
-hook.Add "player_disconnect", "CFC_ChatTransit_PlayerCountTracker", ChatTransit.TrackPlayerCountDisconnected
+    hook.Add "player_connect", "CFC_ChatTransit_PlayerCountTracker", .TrackPlayerCountConnected
+    hook.Add "player_disconnect", "CFC_ChatTransit_PlayerCountTracker", .TrackPlayerCountDisconnected


### PR DESCRIPTION
Currently we're using `player\GetCount! + 1` and `player\GetCount! - 1` but those are highly inaccurate and don't account for connecting players resulting in janky situations. After looking around i found that using game events was the best way to keep a way to track playercount. 